### PR TITLE
Remove dependency of `papyrus/event-sourcing`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "papyrus/serializer": "^0.2",
+        "papyrus/serializer": "^0.3",
         "symfony/serializer": "^6.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,90 +4,29 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a55e2ece0f2fb385214c4aaee611ad3",
+    "content-hash": "906a3b2a35d77ba9a0e92e5496a4a235",
     "packages": [
         {
-            "name": "papyrus/event-sourcing",
-            "version": "0.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/papyrusphp/event-sourcing.git",
-                "reference": "b6cbc9fe70c8701d5db36bd4e9bc13c528a08b4d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/papyrusphp/event-sourcing/zipball/b6cbc9fe70c8701d5db36bd4e9bc13c528a08b4d",
-                "reference": "b6cbc9fe70c8701d5db36bd4e9bc13c528a08b4d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.11",
-                "maglnet/composer-require-checker": "^4.2",
-                "phpro/grumphp-shim": "^1.13",
-                "phpstan/phpstan": "^1.8",
-                "phpunit/phpunit": "^9.5",
-                "scrutinizer/ocular": "^1.9"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Papyrus\\EventSourcing\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jeroen de Graaf",
-                    "email": "hello@jero.work"
-                }
-            ],
-            "description": "Yet another event sourcing library for PHP",
-            "keywords": [
-                "cqrs",
-                "ddd",
-                "domain-driven-design",
-                "event-sourcing",
-                "papyrus"
-            ],
-            "support": {
-                "issues": "https://github.com/papyrusphp/event-sourcing/issues",
-                "source": "https://github.com/papyrusphp/event-sourcing/tree/0.2.0"
-            },
-            "time": "2022-10-13T14:28:19+00:00"
-        },
-        {
             "name": "papyrus/serializer",
-            "version": "0.2.0",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/papyrusphp/serializer.git",
-                "reference": "2d9b5261f38adea55b47788b9cec2b21df50d25d"
+                "reference": "065100683249848286731d3f565efccde8a900b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/papyrusphp/serializer/zipball/2d9b5261f38adea55b47788b9cec2b21df50d25d",
-                "reference": "2d9b5261f38adea55b47788b9cec2b21df50d25d",
+                "url": "https://api.github.com/repos/papyrusphp/serializer/zipball/065100683249848286731d3f565efccde8a900b7",
+                "reference": "065100683249848286731d3f565efccde8a900b7",
                 "shasum": ""
             },
             "require": {
-                "papyrus/event-sourcing": "^0.2",
                 "php": "^8.1"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.11",
-                "maglnet/composer-require-checker": "^4.2",
-                "mockery/mockery": "^1.5",
                 "phpro/grumphp-shim": "^1.13",
-                "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-mockery": "^1.1",
-                "phpstan/phpstan-phpunit": "^1.1",
                 "phpunit/phpunit": "^9.5",
                 "scrutinizer/ocular": "^1.9"
             },
@@ -119,9 +58,9 @@
             ],
             "support": {
                 "issues": "https://github.com/papyrusphp/serializer/issues",
-                "source": "https://github.com/papyrusphp/serializer/tree/0.2.0"
+                "source": "https://github.com/papyrusphp/serializer/tree/0.3.0"
             },
-            "time": "2022-10-13T14:34:04+00:00"
+            "time": "2022-10-21T18:11:13+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1767,16 +1706,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.10.0",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "87fa2d526e56737a2ae8fa201a61b15efae59b8a"
+                "reference": "33aefcdab42900e36366d0feab6206e2dd68f947"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/87fa2d526e56737a2ae8fa201a61b15efae59b8a",
-                "reference": "87fa2d526e56737a2ae8fa201a61b15efae59b8a",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/33aefcdab42900e36366d0feab6206e2dd68f947",
+                "reference": "33aefcdab42900e36366d0feab6206e2dd68f947",
                 "shasum": ""
             },
             "require": {
@@ -1806,9 +1745,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.10.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.13.0"
             },
-            "time": "2022-10-12T19:19:18+00:00"
+            "time": "2022-10-21T09:57:39+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/tests/Stub/TestDomainEvent.php
+++ b/tests/Stub/TestDomainEvent.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Papyrus\SymfonySerializer\Test\Stub;
 
 use DateTimeImmutable;
-use Papyrus\EventSourcing\DomainEvent;
 
-final class TestDomainEvent implements DomainEvent
+final class TestDomainEvent
 {
     /**
      * @param array<mixed> $array
@@ -21,10 +20,5 @@ final class TestDomainEvent implements DomainEvent
         public readonly DateTimeImmutable $dateTimeImmutable,
         public readonly ?string $nullableString,
     ) {
-    }
-
-    public function getAggregateRootId(): string
-    {
-        return $this->aggregateRootId;
     }
 }


### PR DESCRIPTION
Your domain layer should not rely on external code. Therefore the library `papyrus/event-sourcing` should not be used as vendor, instead copy or build your own. All papyrus libraries should therefore not rely on this library.